### PR TITLE
Fix: Start site with white mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,8 +10,7 @@
     <!-- Prevent flash of unstyled content for dark mode -->
     <script>
       (function() {
-        const theme = localStorage.getItem('theme') || 
-          (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+        const theme = localStorage.getItem('theme') || 'light';
         if (theme === 'dark') {
           document.documentElement.classList.add('dark');
         }


### PR DESCRIPTION
The site was starting with dark mode. This commit ensures the site always starts with the default white mode.